### PR TITLE
Ensure zsh environment is available when cloning

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,7 +1,10 @@
-#!/bin/sh
+#!/usr/local/bin/zsh
+
+# Ensure ZSH environment is loaded
+source ~/.zshrc
 
 # JavaScript
-if [ -e yarn.lock ]; then
+if [ -e yarn.lock ] || [ -e package.json ]; then
   yarn install
 fi
 

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,7 +1,10 @@
-#!/bin/sh
+#!/usr/local/bin/zsh
+
+# Ensure ZSH environment is loaded
+source ~/.zshrc
 
 # JavaScript
-if [ -e yarn.lock ]; then
+if [ -e yarn.lock ] || [ -e package.json ]; then
   yarn install
 fi
 


### PR DESCRIPTION
Without this the system version of ruby (without bundler) is used and scripts failed.

Same happens with yarn, because it is not installed outside of `nodenv`.