### PR TITLE
Ignore vscode workspaces

### DIFF
--- a/.gitignore-global
+++ b/.gitignore-global
@@ -17,3 +17,4 @@ ehthumbs.db
 .vscode
 .go-version
 venv
+*.code-workspace


### PR DESCRIPTION
They can be added forcefully with -f if really needed on a per project basis