### PR TITLE
Add a custom tmux status bar theme

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -48,8 +48,8 @@ set -g status-left "#(~/.tmux/status-left.sh '#{pane_current_path}')"
 
 # Window list: each tab is a slanted block; no separator so edges butt cleanly.
 set -g window-status-separator ""
-set -g window-status-format " #[fg=#2e3440,bg=#3b4252]#[fg=#7b88a1,bg=#3b4252] #{?#{==:#{pane_current_command},claude},󱜚 ,}#I #{?#{==:#{pane_title},#{host}},#W,#{=16:#{pane_title}}}#{?@workmux_status, #{?#{==:#{@workmux_status},󱓦},#[fg=#ebcb8b],#{?#{==:#{@workmux_status},󰠗},#[fg=#d08770],#{?#{==:#{@workmux_status},},#[fg=#a3be8c],#[fg=#7b88a1]}}}#{@workmux_status}#[fg=#7b88a1],} #[fg=#3b4252,bg=#2e3440]"
-set -g window-status-current-format " #[fg=#2e3440,bg=#88c0d0]#[fg=#2e3440,bg=#88c0d0,bold] #{?#{==:#{pane_current_command},claude},󱜚 ,}#I #{?#{==:#{pane_title},#{host}},#W,#{=16:#{pane_title}}}#{?@workmux_status, #{@workmux_status},} #[fg=#88c0d0,bg=#2e3440,nobold]"
+set -g window-status-format "#[fg=#2e3440,bg=#3b4252]#[fg=#7b88a1,bg=#3b4252] #{?#{==:#{pane_current_command},claude},󱜚 ,}#I #{?#{==:#{pane_title},#{host}},#W,#{=16:#{pane_title}}}#{?@workmux_status, #{?#{==:#{@workmux_status},󱓦},#[fg=#ebcb8b],#{?#{==:#{@workmux_status},󰠗},#[fg=#d08770],#{?#{==:#{@workmux_status},},#[fg=#a3be8c],#[fg=#7b88a1]}}}#{@workmux_status}#[fg=#7b88a1],} #[fg=#3b4252,bg=#2e3440]"
+set -g window-status-current-format "#[fg=#2e3440,bg=#88c0d0]#[fg=#2e3440,bg=#88c0d0,bold] #{?#{==:#{pane_current_command},claude},󱜚 ,}#I #{?#{==:#{pane_title},#{host}},#W,#{=16:#{pane_title}}}#{?@workmux_status, #{@workmux_status},} #[fg=#88c0d0,bg=#2e3440,nobold]"
 
 # Right: active pane's title (the terminal/program-set description).
 set -g status-right "#[fg=#2e3440,bg=#434c5e]#[fg=#d8dee9,bg=#434c5e] #{pane_title} "

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -48,8 +48,8 @@ set -g status-left "#(~/.tmux/status-left.sh '#{pane_current_path}')"
 
 # Window list: each tab is a slanted block; no separator so edges butt cleanly.
 set -g window-status-separator ""
-set -g window-status-format " #[fg=#3b4252,bg=#2e3440]#[fg=#7b88a1,bg=#3b4252] #{?@workmux_status,#{?#{==:#{@workmux_status},󱙺},#[fg=#ebcb8b],#{?#{==:#{@workmux_status},󱚠},#[fg=#d08770],#{?#{==:#{@workmux_status},󱜚},#[fg=#a3be8c],#[fg=#7b88a1]}}}#{@workmux_status}#[fg=#7b88a1] ,}#I #{?#{==:#{pane_title},#{host}},#W,#{=16:#{pane_title}}} #[fg=#3b4252,bg=#2e3440]"
-set -g window-status-current-format " #[fg=#88c0d0,bg=#2e3440]#[fg=#2e3440,bg=#88c0d0,bold] #{?@workmux_status,#{@workmux_status} ,}#I #{?#{==:#{pane_title},#{host}},#W,#{=16:#{pane_title}}} #[fg=#88c0d0,bg=#2e3440,nobold]"
+set -g window-status-format " #[fg=#3b4252,bg=#2e3440]#[fg=#7b88a1,bg=#3b4252] #{?#{==:#{pane_current_command},claude},󱜚 ,}#I #{?#{==:#{pane_title},#{host}},#W,#{=16:#{pane_title}}}#{?@workmux_status, #{?#{==:#{@workmux_status},󱓦},#[fg=#ebcb8b],#{?#{==:#{@workmux_status},󰠗},#[fg=#d08770],#{?#{==:#{@workmux_status},},#[fg=#a3be8c],#[fg=#7b88a1]}}}#{@workmux_status}#[fg=#7b88a1],} #[fg=#3b4252,bg=#2e3440]"
+set -g window-status-current-format " #[fg=#88c0d0,bg=#2e3440]#[fg=#2e3440,bg=#88c0d0,bold] #{?#{==:#{pane_current_command},claude},󱜚 ,}#I #{?#{==:#{pane_title},#{host}},#W,#{=16:#{pane_title}}}#{?@workmux_status, #{@workmux_status},} #[fg=#88c0d0,bg=#2e3440,nobold]"
 
 # Right: active pane's title (the terminal/program-set description).
 set -g status-right "#[fg=#434c5e,bg=#2e3440]#[fg=#d8dee9,bg=#434c5e] #{pane_title} "

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -21,3 +21,35 @@ bind -n M-Down select-pane -D
 # Start windows and panes at 1, not 0
 set -g base-index 1
 setw -g pane-base-index 1
+
+# ── Theme (nova-inspired, no plugins) ─────────────────────────────────────────
+# Slanted powerline status bar. Palette is kept in sync with the helper script
+# ~/.tmux/status-left.sh (which renders the path + git-branch segments).
+#
+#   [ folder/path ][ git-branch ]   [1 tab][2 tab]…            [ pane title ]
+#
+# Powerline/folder glyphs require a Nerd Font (CascadiaMonoNF is installed).
+# Palette (Nord-based): base #2e3440 · grey #3b4252 · slate #434c5e ·
+#   accent #88c0d0 · text #d8dee9 · dim #7b88a1 · branch #81a1c1
+
+# True colour so the hex palette renders accurately.
+set -g default-terminal "tmux-256color"
+set -ga terminal-overrides ",*256col*:Tc,xterm*:Tc"
+
+set -g status on
+set -g status-interval 5
+set -g status-justify left
+set -g status-left-length 200
+set -g status-right-length 100
+set -g status-style "fg=#d8dee9,bg=#2e3440"
+
+# Left: folder/path segment + optional git branch (rendered by the helper).
+set -g status-left "#(~/.tmux/status-left.sh '#{pane_current_path}')"
+
+# Window list: each tab is a slanted block; no separator so edges butt cleanly.
+set -g window-status-separator ""
+set -g window-status-format " #[fg=#3b4252,bg=#2e3440]#[fg=#7b88a1,bg=#3b4252] #I #W#{?@workmux_status, #{@workmux_status},} #[fg=#3b4252,bg=#2e3440]"
+set -g window-status-current-format " #[fg=#88c0d0,bg=#2e3440]#[fg=#2e3440,bg=#88c0d0,bold] #I #W#{?@workmux_status, #{@workmux_status},} #[fg=#88c0d0,bg=#2e3440,nobold]"
+
+# Right: active pane's title (the terminal/program-set description).
+set -g status-right "#[fg=#434c5e,bg=#2e3440]#[fg=#d8dee9,bg=#434c5e] #{pane_title} "

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -48,8 +48,8 @@ set -g status-left "#(~/.tmux/status-left.sh '#{pane_current_path}')"
 
 # Window list: each tab is a slanted block; no separator so edges butt cleanly.
 set -g window-status-separator ""
-set -g window-status-format "#[fg=#2e3440,bg=#3b4252]#[fg=#7b88a1,bg=#3b4252] #{?#{==:#{pane_current_command},claude},󱜚 ,}#I #{?#{==:#{pane_title},#{host}},#W,#{=16:#{pane_title}}}#{?@workmux_status, #{?#{==:#{@workmux_status},󱓦},#[fg=#ebcb8b],#{?#{==:#{@workmux_status},󰠗},#[fg=#d08770],#{?#{==:#{@workmux_status},},#[fg=#a3be8c],#[fg=#7b88a1]}}}#{@workmux_status}#[fg=#7b88a1],} #[fg=#3b4252,bg=#2e3440]"
-set -g window-status-current-format "#[fg=#2e3440,bg=#88c0d0]#[fg=#2e3440,bg=#88c0d0,bold] #{?#{==:#{pane_current_command},claude},󱜚 ,}#I #{?#{==:#{pane_title},#{host}},#W,#{=16:#{pane_title}}}#{?@workmux_status, #{@workmux_status},} #[fg=#88c0d0,bg=#2e3440,nobold]"
+set -g window-status-format "#[fg=#2e3440,bg=#3b4252]#[fg=#7b88a1,bg=#3b4252] #{?#{==:#{pane_current_command},claude},󱜚 ,}#I #{?#{==:#{pane_title},#{host}},#W,#{=/16/…:#{pane_title}}}#{?@workmux_status, #{?#{==:#{@workmux_status},󱓦},#[fg=#ebcb8b],#{?#{==:#{@workmux_status},󰠗},#[fg=#d08770],#{?#{==:#{@workmux_status},},#[fg=#a3be8c],#[fg=#7b88a1]}}}#{@workmux_status}#[fg=#7b88a1],} #[fg=#3b4252,bg=#2e3440]"
+set -g window-status-current-format "#[fg=#2e3440,bg=#88c0d0]#[fg=#2e3440,bg=#88c0d0,bold] #{?#{==:#{pane_current_command},claude},󱜚 ,}#I #{?#{==:#{pane_title},#{host}},#W,#{=/16/…:#{pane_title}}}#{?@workmux_status, #{@workmux_status},} #[fg=#88c0d0,bg=#2e3440,nobold]"
 
 # Right: active pane's title (the terminal/program-set description).
 set -g status-right "#[fg=#2e3440,bg=#434c5e]#[fg=#d8dee9,bg=#434c5e] #{pane_title} "

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -48,8 +48,8 @@ set -g status-left "#(~/.tmux/status-left.sh '#{pane_current_path}')"
 
 # Window list: each tab is a slanted block; no separator so edges butt cleanly.
 set -g window-status-separator ""
-set -g window-status-format " #[fg=#3b4252,bg=#2e3440]#[fg=#7b88a1,bg=#3b4252] #I #{?#{==:#{pane_title},#{host}},#W,#{=16:#{pane_title}}}#{?@workmux_status, #{?#{==:#{@workmux_status},󰚩},#[fg=#ebcb8b],#{?#{==:#{@workmux_status},},#[fg=#d08770],#{?#{==:#{@workmux_status},},#[fg=#a3be8c],#[fg=#7b88a1]}}}#{@workmux_status}#[fg=#7b88a1],} #[fg=#3b4252,bg=#2e3440]"
-set -g window-status-current-format " #[fg=#88c0d0,bg=#2e3440]#[fg=#2e3440,bg=#88c0d0,bold] #I #{?#{==:#{pane_title},#{host}},#W,#{=16:#{pane_title}}}#{?@workmux_status, #{@workmux_status},} #[fg=#88c0d0,bg=#2e3440,nobold]"
+set -g window-status-format " #[fg=#3b4252,bg=#2e3440]#[fg=#7b88a1,bg=#3b4252] #{?@workmux_status,#{?#{==:#{@workmux_status},󱙺},#[fg=#ebcb8b],#{?#{==:#{@workmux_status},󱚠},#[fg=#d08770],#{?#{==:#{@workmux_status},󱜚},#[fg=#a3be8c],#[fg=#7b88a1]}}}#{@workmux_status}#[fg=#7b88a1] ,}#I #{?#{==:#{pane_title},#{host}},#W,#{=16:#{pane_title}}} #[fg=#3b4252,bg=#2e3440]"
+set -g window-status-current-format " #[fg=#88c0d0,bg=#2e3440]#[fg=#2e3440,bg=#88c0d0,bold] #{?@workmux_status,#{@workmux_status} ,}#I #{?#{==:#{pane_title},#{host}},#W,#{=16:#{pane_title}}} #[fg=#88c0d0,bg=#2e3440,nobold]"
 
 # Right: active pane's title (the terminal/program-set description).
 set -g status-right "#[fg=#434c5e,bg=#2e3440]#[fg=#d8dee9,bg=#434c5e] #{pane_title} "

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -48,7 +48,7 @@ set -g status-left "#(~/.tmux/status-left.sh '#{pane_current_path}')"
 
 # Window list: each tab is a slanted block; no separator so edges butt cleanly.
 set -g window-status-separator ""
-set -g window-status-format " #[fg=#3b4252,bg=#2e3440]#[fg=#7b88a1,bg=#3b4252] #I #W#{?@workmux_status, #{@workmux_status},} #[fg=#3b4252,bg=#2e3440]"
+set -g window-status-format " #[fg=#3b4252,bg=#2e3440]#[fg=#7b88a1,bg=#3b4252] #I #W#{?@workmux_status, #{?#{==:#{@workmux_status},󰚩},#[fg=#ebcb8b],#{?#{==:#{@workmux_status},},#[fg=#d08770],#{?#{==:#{@workmux_status},},#[fg=#a3be8c],#[fg=#7b88a1]}}}#{@workmux_status}#[fg=#7b88a1],} #[fg=#3b4252,bg=#2e3440]"
 set -g window-status-current-format " #[fg=#88c0d0,bg=#2e3440]#[fg=#2e3440,bg=#88c0d0,bold] #I #W#{?@workmux_status, #{@workmux_status},} #[fg=#88c0d0,bg=#2e3440,nobold]"
 
 # Right: active pane's title (the terminal/program-set description).

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -48,8 +48,8 @@ set -g status-left "#(~/.tmux/status-left.sh '#{pane_current_path}')"
 
 # Window list: each tab is a slanted block; no separator so edges butt cleanly.
 set -g window-status-separator ""
-set -g window-status-format " #[fg=#3b4252,bg=#2e3440]#[fg=#7b88a1,bg=#3b4252] #I #W#{?@workmux_status, #{?#{==:#{@workmux_status},󰚩},#[fg=#ebcb8b],#{?#{==:#{@workmux_status},},#[fg=#d08770],#{?#{==:#{@workmux_status},},#[fg=#a3be8c],#[fg=#7b88a1]}}}#{@workmux_status}#[fg=#7b88a1],} #[fg=#3b4252,bg=#2e3440]"
-set -g window-status-current-format " #[fg=#88c0d0,bg=#2e3440]#[fg=#2e3440,bg=#88c0d0,bold] #I #W#{?@workmux_status, #{@workmux_status},} #[fg=#88c0d0,bg=#2e3440,nobold]"
+set -g window-status-format " #[fg=#3b4252,bg=#2e3440]#[fg=#7b88a1,bg=#3b4252] #I #{?#{==:#{pane_title},#{host}},#W,#{=16:#{pane_title}}}#{?@workmux_status, #{?#{==:#{@workmux_status},󰚩},#[fg=#ebcb8b],#{?#{==:#{@workmux_status},},#[fg=#d08770],#{?#{==:#{@workmux_status},},#[fg=#a3be8c],#[fg=#7b88a1]}}}#{@workmux_status}#[fg=#7b88a1],} #[fg=#3b4252,bg=#2e3440]"
+set -g window-status-current-format " #[fg=#88c0d0,bg=#2e3440]#[fg=#2e3440,bg=#88c0d0,bold] #I #{?#{==:#{pane_title},#{host}},#W,#{=16:#{pane_title}}}#{?@workmux_status, #{@workmux_status},} #[fg=#88c0d0,bg=#2e3440,nobold]"
 
 # Right: active pane's title (the terminal/program-set description).
 set -g status-right "#[fg=#434c5e,bg=#2e3440]#[fg=#d8dee9,bg=#434c5e] #{pane_title} "

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -48,8 +48,8 @@ set -g status-left "#(~/.tmux/status-left.sh '#{pane_current_path}')"
 
 # Window list: each tab is a slanted block; no separator so edges butt cleanly.
 set -g window-status-separator ""
-set -g window-status-format " #[fg=#3b4252,bg=#2e3440]#[fg=#7b88a1,bg=#3b4252] #{?#{==:#{pane_current_command},claude},󱜚 ,}#I #{?#{==:#{pane_title},#{host}},#W,#{=16:#{pane_title}}}#{?@workmux_status, #{?#{==:#{@workmux_status},󱓦},#[fg=#ebcb8b],#{?#{==:#{@workmux_status},󰠗},#[fg=#d08770],#{?#{==:#{@workmux_status},},#[fg=#a3be8c],#[fg=#7b88a1]}}}#{@workmux_status}#[fg=#7b88a1],} #[fg=#3b4252,bg=#2e3440]"
-set -g window-status-current-format " #[fg=#88c0d0,bg=#2e3440]#[fg=#2e3440,bg=#88c0d0,bold] #{?#{==:#{pane_current_command},claude},󱜚 ,}#I #{?#{==:#{pane_title},#{host}},#W,#{=16:#{pane_title}}}#{?@workmux_status, #{@workmux_status},} #[fg=#88c0d0,bg=#2e3440,nobold]"
+set -g window-status-format " #[fg=#2e3440,bg=#3b4252]#[fg=#7b88a1,bg=#3b4252] #{?#{==:#{pane_current_command},claude},󱜚 ,}#I #{?#{==:#{pane_title},#{host}},#W,#{=16:#{pane_title}}}#{?@workmux_status, #{?#{==:#{@workmux_status},󱓦},#[fg=#ebcb8b],#{?#{==:#{@workmux_status},󰠗},#[fg=#d08770],#{?#{==:#{@workmux_status},},#[fg=#a3be8c],#[fg=#7b88a1]}}}#{@workmux_status}#[fg=#7b88a1],} #[fg=#3b4252,bg=#2e3440]"
+set -g window-status-current-format " #[fg=#2e3440,bg=#88c0d0]#[fg=#2e3440,bg=#88c0d0,bold] #{?#{==:#{pane_current_command},claude},󱜚 ,}#I #{?#{==:#{pane_title},#{host}},#W,#{=16:#{pane_title}}}#{?@workmux_status, #{@workmux_status},} #[fg=#88c0d0,bg=#2e3440,nobold]"
 
 # Right: active pane's title (the terminal/program-set description).
-set -g status-right "#[fg=#434c5e,bg=#2e3440]#[fg=#d8dee9,bg=#434c5e] #{pane_title} "
+set -g status-right "#[fg=#2e3440,bg=#434c5e]#[fg=#d8dee9,bg=#434c5e] #{pane_title} "

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -22,7 +22,7 @@ bind -n M-Down select-pane -D
 set -g base-index 1
 setw -g pane-base-index 1
 
-# ── Theme (nova-inspired, no plugins) ─────────────────────────────────────────
+# ── Theme (no plugins) ────────────────────────────────────────────────────────
 # Slanted powerline status bar. Palette is kept in sync with the helper script
 # ~/.tmux/status-left.sh (which renders the path + git-branch segments).
 #

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -28,7 +28,7 @@ symlink_dotfile tmux
 echo ""
 symlink "$DOTFILES_DIR/vscode/settings.json" "$HOME/Library/Application Support/Code/User/settings.json"
 symlink "$DOTFILES_DIR/macos/quick-actions/copy-path" "$HOME/Library/Services/copy-path.workflow"
-symlink "$DOTFILES_DIR/.workmux.yaml" "$HOME/.config/workmux/config.yaml"
+symlink "$DOTFILES_DIR/workmux/config.yaml" "$HOME/.config/workmux/config.yaml"
 
 # vscode snippets cannot be symlinked
 echo ""

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -23,6 +23,7 @@ symlink_dotfile tigrc
 symlink_dotfile gnupg/gpg.conf
 symlink_dotfile gnupg/gpg-agent.conf
 symlink_dotfile tmux.conf
+symlink_dotfile tmux
 
 echo ""
 symlink "$DOTFILES_DIR/vscode/settings.json" "$HOME/Library/Application Support/Code/User/settings.json"

--- a/tmux/status-left.sh
+++ b/tmux/status-left.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env sh
+#
+# tmux status-left renderer (nova-inspired, no plugins).
+#
+# Invoked from ~/.tmux.conf as:
+#   status-left "#(~/.tmux/status-left.sh '#{pane_current_path}')"
+#
+# Emits an already-styled left block: a folder/path segment plus an optional
+# git-branch segment, with slanted powerline borders. tmux re-parses the
+# `#[...]` format codes in this output, so we build the whole block here.
+#
+# Path logic mirrors `maybe_src_path` in ~/.zsh/marcqualie.zsh-theme and the
+# read-only git lookup mirrors `__git` / `git_prompt_info` in ~/.zsh/git.zsh:
+#   - inside ~/src/<group>/<project>...  ->  "GH <group>/<project>..." (+ branch)
+#   - exactly ~/src                      ->  "GH"
+#   - $HOME                              ->  "~"
+#   - anywhere else                      ->  full path ($HOME shortened to ~)
+
+# --- palette (kept in sync with ~/.tmux.conf) ---------------------------------
+base="#2e3440"      # status bar background
+path_bg="#434c5e"   # path segment background
+path_fg="#eceff4"   # path segment text
+branch_bg="#3b4252" # branch segment background
+branch_fg="#81a1c1" # branch segment text (nova blue)
+
+# --- glyphs (Nerd Font: CascadiaMonoNF) ---------------------------------------
+slant=""           # U+E0B0 solid right-pointing slant
+folder=""          # U+F07B folder
+git_glyph=""       # U+E0A0 powerline branch
+
+dir="${1:-$HOME}"
+src="$HOME/src"
+branch=""
+
+if [ "$dir" = "$HOME" ]; then
+  label="~"
+elif [ "$dir" = "$src" ]; then
+  label="GH"
+elif [ "${dir#"$src"/}" != "$dir" ]; then
+  # Inside ~/src/<group>/<project>...
+  label="GH ${dir#"$src"/}"
+  branch=$(GIT_OPTIONAL_LOCKS=0 git -C "$dir" symbolic-ref --short HEAD 2>/dev/null)
+else
+  case "$dir" in
+    "$HOME"/*) label="~${dir#"$HOME"}" ;;
+    *) label="$dir" ;;
+  esac
+fi
+
+# Path segment.
+printf '#[fg=%s,bg=%s,bold] %s %s ' "$path_fg" "$path_bg" "$folder" "$label"
+
+if [ -n "$branch" ]; then
+  # path -> branch slant, branch segment, branch -> base slant.
+  printf '#[fg=%s,bg=%s,nobold]%s' "$path_bg" "$branch_bg" "$slant"
+  printf '#[fg=%s,bg=%s] %s %s ' "$branch_fg" "$branch_bg" "$git_glyph" "$branch"
+  printf '#[fg=%s,bg=%s,nobold]%s' "$branch_bg" "$base" "$slant"
+else
+  # path -> base slant.
+  printf '#[fg=%s,bg=%s,nobold]%s' "$path_bg" "$base" "$slant"
+fi

--- a/tmux/status-left.sh
+++ b/tmux/status-left.sh
@@ -21,8 +21,7 @@
 base="#2e3440"      # status bar background
 seg1_bg="#434c5e"   # repo/path segment background
 seg1_fg="#eceff4"   # repo/path segment text
-seg2_bg="#3b4252"   # branch segment background
-seg2_fg="#81a1c1"   # branch segment text (nova blue)
+seg2_fg="#81a1c1"   # branch text (nova blue), shown on the same bg as the path
 dirty_fg="#ebcb8b"  # dirty working-tree marker (yellow), mirrors the zsh prompt
 
 # --- glyphs (Nerd Font: CascadiaMonoNF), built via octal to keep this ASCII ---
@@ -107,15 +106,12 @@ else
   fi
 fi
 
-# Repo/path segment.
-printf '#[fg=%s,bg=%s,bold] %s %s ' "$seg1_fg" "$seg1_bg" "$icon" "$label"
+# Repo/path + branch on a single segment: one shared background, no separator
+# between them (just a space), then one slant into the bar background.
+printf '#[fg=%s,bg=%s,bold] %s %s' "$seg1_fg" "$seg1_bg" "$icon" "$label"
 
 if [ -n "$branch" ]; then
-  # seg1 -> seg2 slant, branch segment, seg2 -> base slant.
-  printf '#[fg=%s,bg=%s,nobold]%s' "$seg1_bg" "$seg2_bg" "$slant"
-  printf '#[fg=%s,bg=%s] %s %s%s ' "$seg2_fg" "$seg2_bg" "$bicon" "$branch" "$dirty"
-  printf '#[fg=%s,bg=%s,nobold]%s' "$seg2_bg" "$base" "$slant"
-else
-  # seg1 -> base slant.
-  printf '#[fg=%s,bg=%s,nobold]%s' "$seg1_bg" "$base" "$slant"
+  printf '#[fg=%s,bg=%s,nobold] %s %s%s' "$seg2_fg" "$seg1_bg" "$bicon" "$branch" "$dirty"
 fi
+
+printf ' #[fg=%s,bg=%s,nobold]%s' "$seg1_bg" "$base" "$slant"

--- a/tmux/status-left.sh
+++ b/tmux/status-left.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 #
-# tmux status-left renderer (nova-inspired, no plugins).
+# tmux status-left renderer (no plugins).
 #
 # Invoked from ~/.tmux.conf as:
 #   status-left "#(~/.tmux/status-left.sh '#{pane_current_path}')"
@@ -21,7 +21,7 @@
 base="#2e3440"      # status bar background
 seg1_bg="#434c5e"   # repo/path segment background
 seg1_fg="#eceff4"   # repo/path segment text
-seg2_fg="#81a1c1"   # branch text (nova blue), shown on the same bg as the path
+seg2_fg="#81a1c1"   # branch text (blue), shown on the same bg as the path
 dirty_fg="#ebcb8b"  # dirty working-tree marker (yellow), mirrors the zsh prompt
 
 # --- glyphs (Nerd Font: CascadiaMonoNF), built via octal to keep this ASCII ---

--- a/tmux/status-left.sh
+++ b/tmux/status-left.sh
@@ -28,24 +28,26 @@ seg2_fg="#81a1c1"   # branch segment text (nova blue)
 gh_icon=$(printf '\357\202\233')        # U+F09B  GitHub mark
 git_icon=$(printf '\356\234\202')       # U+E702  git
 folder_icon=$(printf '\357\201\273')    # U+F07B  folder
-branch_icon=$(printf '\356\202\240')    # U+E0A0  branch
-worktree_icon=$(printf '\357\204\246')  # U+F126  fork (linked worktree)
+branch_icon=$(printf '\357\204\246')          # U+F126  branch (normal checkout)
+worktree_branch_icon=$(printf '\356\251\243') # U+EA63  branch (linked worktree)
 slant=$(printf '\356\202\260')          # U+E0B0  solid right slant
 
 dir="${1:-$HOME}"
 icon=""
 label=""
 branch=""
-wt=""
+bicon=""
 
 if git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   # Current branch, falling back to a short SHA when HEAD is detached.
   branch=$(GIT_OPTIONAL_LOCKS=0 git -C "$dir" symbolic-ref --short HEAD 2>/dev/null)
   [ -n "$branch" ] || branch=$(GIT_OPTIONAL_LOCKS=0 git -C "$dir" rev-parse --short HEAD 2>/dev/null)
 
-  # Linked worktrees live under <repo>/.git/worktrees/<name>.
+  # Linked worktrees live under <repo>/.git/worktrees/<name>; swap the branch
+  # icon to signal a worktree rather than appending a second glyph.
+  bicon=$branch_icon
   case "$(git -C "$dir" rev-parse --git-dir 2>/dev/null)" in
-    */worktrees/*) wt=" $worktree_icon" ;;
+    */worktrees/*) bicon=$worktree_branch_icon ;;
   esac
 
   # Parse host + owner/repo from the origin URL (https, ssh, or scp-like).
@@ -102,7 +104,7 @@ printf '#[fg=%s,bg=%s,bold] %s %s ' "$seg1_fg" "$seg1_bg" "$icon" "$label"
 if [ -n "$branch" ]; then
   # seg1 -> seg2 slant, branch segment, seg2 -> base slant.
   printf '#[fg=%s,bg=%s,nobold]%s' "$seg1_bg" "$seg2_bg" "$slant"
-  printf '#[fg=%s,bg=%s] %s %s%s ' "$seg2_fg" "$seg2_bg" "$branch_icon" "$branch" "$wt"
+  printf '#[fg=%s,bg=%s] %s %s ' "$seg2_fg" "$seg2_bg" "$bicon" "$branch"
   printf '#[fg=%s,bg=%s,nobold]%s' "$seg2_bg" "$base" "$slant"
 else
   # seg1 -> base slant.

--- a/tmux/status-left.sh
+++ b/tmux/status-left.sh
@@ -23,6 +23,7 @@ seg1_bg="#434c5e"   # repo/path segment background
 seg1_fg="#eceff4"   # repo/path segment text
 seg2_bg="#3b4252"   # branch segment background
 seg2_fg="#81a1c1"   # branch segment text (nova blue)
+dirty_fg="#ebcb8b"  # dirty working-tree marker (yellow), mirrors the zsh prompt
 
 # --- glyphs (Nerd Font: CascadiaMonoNF), built via octal to keep this ASCII ---
 gh_icon=$(printf '\357\202\233')        # U+F09B  GitHub mark
@@ -31,12 +32,14 @@ folder_icon=$(printf '\357\201\273')    # U+F07B  folder
 branch_icon=$(printf '\357\204\246')          # U+F126  branch (normal checkout)
 worktree_branch_icon=$(printf '\356\251\243') # U+EA63  branch (linked worktree)
 slant=$(printf '\356\202\260')          # U+E0B0  solid right slant
+dirty_glyph=$(printf '\342\234\227')    # U+2717  ballot X (dirty working tree)
 
 dir="${1:-$HOME}"
 icon=""
 label=""
 branch=""
 bicon=""
+dirty=""
 
 if git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   # Current branch, falling back to a short SHA when HEAD is detached.
@@ -49,6 +52,12 @@ if git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   case "$(git -C "$dir" rev-parse --git-dir 2>/dev/null)" in
     */worktrees/*) bicon=$worktree_branch_icon ;;
   esac
+
+  # Yellow cross when the working tree is dirty (untracked counts), mirroring
+  # parse_git_dirty in ~/.zsh/git.zsh.
+  if [ -n "$(GIT_OPTIONAL_LOCKS=0 git -C "$dir" status --porcelain 2>/dev/null)" ]; then
+    dirty=" #[fg=$dirty_fg]$dirty_glyph"
+  fi
 
   # Parse host + owner/repo from the origin URL (https, ssh, or scp-like).
   url=$(git -C "$dir" config --get remote.origin.url 2>/dev/null)
@@ -104,7 +113,7 @@ printf '#[fg=%s,bg=%s,bold] %s %s ' "$seg1_fg" "$seg1_bg" "$icon" "$label"
 if [ -n "$branch" ]; then
   # seg1 -> seg2 slant, branch segment, seg2 -> base slant.
   printf '#[fg=%s,bg=%s,nobold]%s' "$seg1_bg" "$seg2_bg" "$slant"
-  printf '#[fg=%s,bg=%s] %s %s ' "$seg2_fg" "$seg2_bg" "$bicon" "$branch"
+  printf '#[fg=%s,bg=%s] %s %s%s ' "$seg2_fg" "$seg2_bg" "$bicon" "$branch" "$dirty"
   printf '#[fg=%s,bg=%s,nobold]%s' "$seg2_bg" "$base" "$slant"
 else
   # seg1 -> base slant.

--- a/tmux/status-left.sh
+++ b/tmux/status-left.sh
@@ -5,57 +5,106 @@
 # Invoked from ~/.tmux.conf as:
 #   status-left "#(~/.tmux/status-left.sh '#{pane_current_path}')"
 #
-# Emits an already-styled left block: a folder/path segment plus an optional
-# git-branch segment, with slanted powerline borders. tmux re-parses the
-# `#[...]` format codes in this output, so we build the whole block here.
+# Emits an already-styled left block (tmux re-parses the `#[...]` format codes
+# in this output). The left block describes the active pane's directory:
 #
-# Path logic mirrors `maybe_src_path` in ~/.zsh/marcqualie.zsh-theme and the
-# read-only git lookup mirrors `__git` / `git_prompt_info` in ~/.zsh/git.zsh:
-#   - inside ~/src/<group>/<project>...  ->  "GH <group>/<project>..." (+ branch)
-#   - exactly ~/src                      ->  "GH"
-#   - $HOME                              ->  "~"
-#   - anywhere else                      ->  full path ($HOME shortened to ~)
+#   GitHub repo      ->   owner/repo        + branch   (GitHub icon)
+#   other git repo   ->   repo              + branch   (git icon)
+#   not a git repo   ->   parent/dir (<=2)             (folder icon)
+#
+# A worktree icon is appended to the branch when the pane is in a linked git
+# worktree (e.g. one created by workmux) rather than the main checkout.
+#
+# Git lookups are read-only (GIT_OPTIONAL_LOCKS=0, mirroring ~/.zsh/git.zsh).
 
 # --- palette (kept in sync with ~/.tmux.conf) ---------------------------------
 base="#2e3440"      # status bar background
-path_bg="#434c5e"   # path segment background
-path_fg="#eceff4"   # path segment text
-branch_bg="#3b4252" # branch segment background
-branch_fg="#81a1c1" # branch segment text (nova blue)
+seg1_bg="#434c5e"   # repo/path segment background
+seg1_fg="#eceff4"   # repo/path segment text
+seg2_bg="#3b4252"   # branch segment background
+seg2_fg="#81a1c1"   # branch segment text (nova blue)
 
-# --- glyphs (Nerd Font: CascadiaMonoNF) ---------------------------------------
-slant=""           # U+E0B0 solid right-pointing slant
-folder=""          # U+F07B folder
-git_glyph=""       # U+E0A0 powerline branch
+# --- glyphs (Nerd Font: CascadiaMonoNF), built via octal to keep this ASCII ---
+gh_icon=$(printf '\357\202\233')        # U+F09B  GitHub mark
+git_icon=$(printf '\356\234\202')       # U+E702  git
+folder_icon=$(printf '\357\201\273')    # U+F07B  folder
+branch_icon=$(printf '\356\202\240')    # U+E0A0  branch
+worktree_icon=$(printf '\357\204\246')  # U+F126  fork (linked worktree)
+slant=$(printf '\356\202\260')          # U+E0B0  solid right slant
 
 dir="${1:-$HOME}"
-src="$HOME/src"
+icon=""
+label=""
 branch=""
+wt=""
 
-if [ "$dir" = "$HOME" ]; then
-  label="~"
-elif [ "$dir" = "$src" ]; then
-  label="GH"
-elif [ "${dir#"$src"/}" != "$dir" ]; then
-  # Inside ~/src/<group>/<project>...
-  label="GH ${dir#"$src"/}"
+if git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  # Current branch, falling back to a short SHA when HEAD is detached.
   branch=$(GIT_OPTIONAL_LOCKS=0 git -C "$dir" symbolic-ref --short HEAD 2>/dev/null)
-else
-  case "$dir" in
-    "$HOME"/*) label="~${dir#"$HOME"}" ;;
-    *) label="$dir" ;;
+  [ -n "$branch" ] || branch=$(GIT_OPTIONAL_LOCKS=0 git -C "$dir" rev-parse --short HEAD 2>/dev/null)
+
+  # Linked worktrees live under <repo>/.git/worktrees/<name>.
+  case "$(git -C "$dir" rev-parse --git-dir 2>/dev/null)" in
+    */worktrees/*) wt=" $worktree_icon" ;;
   esac
+
+  # Parse host + owner/repo from the origin URL (https, ssh, or scp-like).
+  url=$(git -C "$dir" config --get remote.origin.url 2>/dev/null)
+  url=${url%.git}
+  host=""
+  path=""
+  case "$url" in
+    "") : ;;
+    *://*) rest=${url#*://}; rest=${rest#*@}; host=${rest%%/*}; path=${rest#*/} ;;
+    *@*:*) rest=${url#*@}; host=${rest%%:*}; path=${rest#*:} ;;
+    *) path=$url ;;
+  esac
+  repo=${path##*/}
+  owner=${path%/*}; owner=${owner##*/}
+
+  case "$host" in
+    github.com)
+      icon=$gh_icon
+      label="$owner/$repo"
+      ;;
+    *)
+      icon=$git_icon
+      if [ -n "$repo" ]; then
+        label="$repo"
+      else
+        label=$(basename "$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)")
+      fi
+      ;;
+  esac
+else
+  # Not a git repo: folder icon + at most the last two path components.
+  icon=$folder_icon
+  if [ "$dir" = "$HOME" ]; then
+    label="~"
+  elif [ "${dir%/*}" = "$HOME" ]; then
+    # literal ~ for display, not a path to expand
+    # shellcheck disable=SC2088
+    label="~/${dir##*/}"
+  else
+    leaf=${dir##*/}
+    parent=${dir%/*}; parent=${parent##*/}
+    if [ -n "$parent" ] && [ "$parent" != "$leaf" ]; then
+      label="$parent/$leaf"
+    else
+      label="$leaf"
+    fi
+  fi
 fi
 
-# Path segment.
-printf '#[fg=%s,bg=%s,bold] %s %s ' "$path_fg" "$path_bg" "$folder" "$label"
+# Repo/path segment.
+printf '#[fg=%s,bg=%s,bold] %s %s ' "$seg1_fg" "$seg1_bg" "$icon" "$label"
 
 if [ -n "$branch" ]; then
-  # path -> branch slant, branch segment, branch -> base slant.
-  printf '#[fg=%s,bg=%s,nobold]%s' "$path_bg" "$branch_bg" "$slant"
-  printf '#[fg=%s,bg=%s] %s %s ' "$branch_fg" "$branch_bg" "$git_glyph" "$branch"
-  printf '#[fg=%s,bg=%s,nobold]%s' "$branch_bg" "$base" "$slant"
+  # seg1 -> seg2 slant, branch segment, seg2 -> base slant.
+  printf '#[fg=%s,bg=%s,nobold]%s' "$seg1_bg" "$seg2_bg" "$slant"
+  printf '#[fg=%s,bg=%s] %s %s%s ' "$seg2_fg" "$seg2_bg" "$branch_icon" "$branch" "$wt"
+  printf '#[fg=%s,bg=%s,nobold]%s' "$seg2_bg" "$base" "$slant"
 else
-  # path -> base slant.
-  printf '#[fg=%s,bg=%s,nobold]%s' "$path_bg" "$base" "$slant"
+  # seg1 -> base slant.
+  printf '#[fg=%s,bg=%s,nobold]%s' "$seg1_bg" "$base" "$slant"
 fi

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -76,6 +76,7 @@
   "testExplorer.codeLens": true,
   "terminal.integrated.enableVisualBell": true,
   "terminal.integrated.bellDuration": 10000,
+  "terminal.integrated.fontFamily": "'Cascadia Mono NF', Menlo, monospace",
   "terminal.integrated.cwd": "${workspaceFolder}",
   "terminal.integrated.initialHint": false,
   "terminal.integrated.profiles.osx": {

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -20,7 +20,7 @@
   "editor.bracketPairColorization.enabled": true,
   "editor.cursorBlinking": "smooth",
   "editor.cursorSmoothCaretAnimation": "on",
-  "editor.fontFamily": "Geist, 'Cascadia Code', Menlo, Monaco, 'Courier New', monospace",
+  "editor.fontFamily": "'Cascadia Mono NF', 'Cascadia Code', Menlo, Monaco, 'Courier New', monospace",
   "editor.fontLigatures": false,
   "editor.formatOnPaste": false,
   "editor.inlineSuggest.enabled": true,

--- a/workmux/config.yaml
+++ b/workmux/config.yaml
@@ -1,0 +1,11 @@
+nerdfont: true
+
+# Don't overwrite the tmux window-status format on agent tabs; the slanted theme
+# in ~/.tmux.conf styles all tabs and renders #{@workmux_status} itself.
+status_format: false
+
+# Nerd Font agent-status icons (rendered inside the themed tmux tab).
+status_icons:
+  working: "󰚩"
+  waiting: ""
+  done: ""

--- a/workmux/config.yaml
+++ b/workmux/config.yaml
@@ -6,6 +6,6 @@ status_format: false
 
 # Nerd Font agent-status icons (rendered inside the themed tmux tab).
 status_icons:
-  working: "󱙺"
-  waiting: "󱚠"
-  done: "󱜚"
+  working: "󱓦"
+  waiting: "󰠗"
+  done: ""

--- a/workmux/config.yaml
+++ b/workmux/config.yaml
@@ -6,6 +6,6 @@ status_format: false
 
 # Nerd Font agent-status icons (rendered inside the themed tmux tab).
 status_icons:
-  working: "󰚩"
-  waiting: ""
-  done: ""
+  working: "󱙺"
+  waiting: "󱚠"
+  done: "󱜚"


### PR DESCRIPTION
A plugin-free tmux status bar, built from scratch (no third-party code pulled in) and wired into the dotfiles bootstrap.

## Layout

<img width="599" height="21" alt="image" src="https://github.com/user-attachments/assets/fea4f7a1-aba2-4c67-8b8a-c512e6793473" />

```
[ owner/repo  branch ✗ ]  [tab][tab]…            [ pane title ]
```

All separators are single-direction arrows.

## Left status (`tmux/status-left.sh`)

A dependency-free helper that derives the left segment from git:
- **GitHub origin** → `owner/repo` + GitHub icon; **other git remote** → repo name + git icon; **non-git** → last ≤2 path components + folder icon (`~` for home).
- Shows the current branch (short SHA when detached); the branch icon changes for a linked **git worktree**.
- Appends a **yellow ✗** when the working tree is dirty, mirroring the zsh prompt's `parse_git_dirty`.
- Path and branch share one background (distinct from the tab background); glyphs are emitted via `printf` octal so the script stays ASCII on disk.

## Window list
- Slanted tabs that butt together; active tab is a filled accent block, inactive tabs dim grey.
- Shows the **pane title** (truncated to 16) when set, else the binary name.
- **claude tabs** (running `claude`) get a robot-happy badge at the start.
- The **workmux** agent-status icon sits at the end, colour-coded: working `clipboard-edit` (amber), needs-input `comment-question` (orange), done `check` (green).

## workmux integration (`workmux/config.yaml`, now tracked)
- `status_format: false` so workmux no longer overrides the themed tab format.
- Nerd Font `status_icons` instead of emoji.
- The global config is moved into the repo and symlinked via bootstrap.

## Fonts (`vscode/settings.json`)
- Point the VSCode integrated terminal **and** editor at `Cascadia Mono NF` so the Nerd Font glyphs render.

## Notes
- Requires a Nerd Font in the terminal (Cascadia Mono NF, already installed).
