### PR TITLE
Minimise the zsh prompt inside tmux

### DIFF
--- a/.zsh/marcqualie.zsh-theme
+++ b/.zsh/marcqualie.zsh-theme
@@ -68,7 +68,13 @@ function color() {
 }
 
 theme_prompt() {
-  PROMPT="$(ssh_info)$(maybe_src_path)$(aws_vault_info)$(git_prompt_info) "
+  # Inside tmux the status bar already shows the path, git branch, etc., so keep
+  # the prompt minimal. Outside tmux, show the full context.
+  if [[ -n "$TMUX" ]]; then
+    PROMPT='$ '
+  else
+    PROMPT="$(ssh_info)$(maybe_src_path)$(aws_vault_info)$(git_prompt_info) "
+  fi
   if [ "$INCOGNISHELL" -eq "1" ]; then
     PROMPT=" 🤫🙈$PROMPT"
   fi


### PR DESCRIPTION
Now that the tmux status bar shows the working directory, git branch, dirty state and more, the full zsh prompt is redundant inside tmux.

## Change
`theme_prompt()` in `.zsh/marcqualie.zsh-theme` now checks `$TMUX`:
- **Inside tmux** → a plain `$ ` prompt.
- **Outside tmux** → the full prompt (ssh / path / aws-vault / git branch), unchanged.

`$TMUX` is set in every tmux pane, so the minimal prompt applies throughout a tmux session while a bare terminal keeps the full context.

## Notes
- The incognishell `🤫🙈` indicator is still prepended in both cases, since that "recorded shell" warning isn't shown in the status bar.
