### PR TITLE
Expand the in-tmux zsh prompt with a multi-line status block

### DIFF
--- a/.zsh/marcqualie.zsh-theme
+++ b/.zsh/marcqualie.zsh-theme
@@ -2,6 +2,10 @@
 # e.g ~/src/project1/web shows "project1/web" instead of just "web" for ambiguous diectories
 
 source ~/.zsh/git.zsh
+source ~/.zsh/repo-context.sh
+
+# High-resolution clock for measuring how long each command takes.
+zmodload zsh/datetime 2>/dev/null
 
 function maybe_src_path() {
   local wd=$(pwd)
@@ -67,11 +71,69 @@ function color() {
   echo "\e[38;5;${1}m"
 }
 
+# --- command timer ------------------------------------------------------------
+# preexec stamps the start time; precmd (theme_prompt) reads it back to report
+# the duration of the command that just ran. _prompt_ran distinguishes a real
+# command from an empty line / fresh shell, so the status line only shows after
+# something actually executed.
+autoload -U add-zsh-hook
+
+function _prompt_timer_start() {
+  _prompt_started=$EPOCHREALTIME
+  _prompt_ran=1
+}
+add-zsh-hook preexec _prompt_timer_start
+
+# Human-friendly elapsed time: ms under a second, seconds under a minute, then
+# Xm Ys. Input is a float number of seconds.
+function _format_duration() {
+  local d=$1
+  if (( d < 1 )); then
+    printf '%.0fms' $(( d * 1000 ))
+  elif (( d < 60 )); then
+    printf '%.1fs' $d
+  else
+    local secs=${d%.*}
+    printf '%dm%02ds' $(( secs / 60 )) $(( secs % 60 ))
+  fi
+}
+
+# Two-line status block printed inside tmux after a command finishes:
+#   <blank>
+#   ● <duration>          (green dot for success, red dot + code for failure)
+#   <blank>
+function _print_status_line() {
+  local exit=$1
+  local circle elapsed
+  if [[ $exit -eq 0 ]]; then
+    circle="%{$fg[green]%}●%{$reset_color%}"
+  else
+    circle="%{$fg[red]%}●%{$reset_color%} %{$fg[red]%}${exit}%{$reset_color%}"
+  fi
+  elapsed=$(_format_duration ${_prompt_started:+$(( EPOCHREALTIME - _prompt_started ))})
+  print -P ""
+  print -P "${circle} %{$FG[240]%}${elapsed}%{$reset_color%}"
+  print -P ""
+}
+
 theme_prompt() {
-  # Inside tmux the status bar already shows the path, git branch, etc., so keep
-  # the prompt minimal. Outside tmux, show the full context.
+  # Capture the just-finished command's exit code first, before anything else
+  # clobbers $?.
+  local exit_code=$?
+
   if [[ -n "$TMUX" ]]; then
-    PROMPT='$ '
+    # Status line for the command that just ran (skipped on a fresh shell or an
+    # empty line, where preexec never fired).
+    if [[ -n "$_prompt_ran" ]]; then
+      _print_status_line $exit_code
+      unset _prompt_ran
+    fi
+
+    # ┏ <icon> <owner/repo | path>
+    # ┗ $
+    repo_context "$PWD"
+    PROMPT="%{$FG[240]%}┏ %{$fg[cyan]%}${RC_ICON} %{$fg_bold[cyan]%}${RC_LABEL}%{$reset_color%}"$'\n'
+    PROMPT+="%{$FG[240]%}┗ %{$reset_color%}\$ "
   else
     PROMPT="$(ssh_info)$(maybe_src_path)$(aws_vault_info)$(git_prompt_info) "
   fi

--- a/.zsh/repo-context.sh
+++ b/.zsh/repo-context.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env sh
+#
+# repo-context.sh — shared repo/path detection for the zsh prompt and the tmux
+# status bar, so both describe the current directory identically:
+#
+#   GitHub repo      ->   owner/repo   (GitHub icon)
+#   other git repo   ->   repo         (git icon)
+#   not a git repo   ->   parent/dir   (folder icon, <=2 components)
+#
+# Source this file once, then call `repo_context <dir>`; it populates the RC_*
+# globals below. Callers apply their own colouring (zsh prompt escapes vs. tmux
+# `#[...]` format codes). Git lookups are read-only (GIT_OPTIONAL_LOCKS=0).
+
+# --- glyphs (Nerd Font: CascadiaMonoNF), built via octal to keep this ASCII ---
+RC_GH_ICON=$(printf '\357\202\233')             # U+F09B  GitHub mark
+RC_GIT_ICON=$(printf '\356\234\202')            # U+E702  git
+RC_FOLDER_ICON=$(printf '\357\201\273')         # U+F07B  folder
+RC_BRANCH_ICON=$(printf '\357\204\246')         # U+F126  branch (normal checkout)
+RC_WORKTREE_BRANCH_ICON=$(printf '\356\251\243') # U+EA63 branch (linked worktree)
+RC_DIRTY_GLYPH=$(printf '\342\234\227')         # U+2717  ballot X (dirty working tree)
+
+# repo_context <dir>
+# Populates:
+#   RC_ICON     icon glyph for the directory (github / git / folder)
+#   RC_KIND     one of: github | git | folder
+#   RC_LABEL    owner/repo (github), repo (other git), or parent/dir (folder)
+#   RC_BRANCH   current branch or short SHA (empty when not a git repo)
+#   RC_BICON    branch icon (worktree variant inside a linked worktree)
+#   RC_DIRTY    1 when the working tree is dirty, else empty
+repo_context() {
+  RC_ICON=""; RC_KIND=""; RC_LABEL=""; RC_BRANCH=""; RC_BICON=""; RC_DIRTY=""
+  rc_dir="${1:-$HOME}"
+
+  if git -C "$rc_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    # Current branch, falling back to a short SHA when HEAD is detached.
+    RC_BRANCH=$(GIT_OPTIONAL_LOCKS=0 git -C "$rc_dir" symbolic-ref --short HEAD 2>/dev/null)
+    [ -n "$RC_BRANCH" ] || RC_BRANCH=$(GIT_OPTIONAL_LOCKS=0 git -C "$rc_dir" rev-parse --short HEAD 2>/dev/null)
+
+    # Linked worktrees live under <repo>/.git/worktrees/<name>; swap the branch
+    # icon to signal a worktree rather than appending a second glyph.
+    RC_BICON=$RC_BRANCH_ICON
+    case "$(git -C "$rc_dir" rev-parse --git-dir 2>/dev/null)" in
+      */worktrees/*) RC_BICON=$RC_WORKTREE_BRANCH_ICON ;;
+    esac
+
+    # Dirty when there is any porcelain output (untracked counts), mirroring
+    # parse_git_dirty in ~/.zsh/git.zsh.
+    if [ -n "$(GIT_OPTIONAL_LOCKS=0 git -C "$rc_dir" status --porcelain 2>/dev/null)" ]; then
+      RC_DIRTY=1
+    fi
+
+    # Parse host + owner/repo from the origin URL (https, ssh, or scp-like).
+    rc_url=$(git -C "$rc_dir" config --get remote.origin.url 2>/dev/null)
+    rc_url=${rc_url%.git}
+    rc_host=""
+    rc_path=""
+    case "$rc_url" in
+      "") : ;;
+      *://*) rc_rest=${rc_url#*://}; rc_rest=${rc_rest#*@}; rc_host=${rc_rest%%/*}; rc_path=${rc_rest#*/} ;;
+      *@*:*) rc_rest=${rc_url#*@}; rc_host=${rc_rest%%:*}; rc_path=${rc_rest#*:} ;;
+      *) rc_path=$rc_url ;;
+    esac
+    rc_repo=${rc_path##*/}
+    rc_owner=${rc_path%/*}; rc_owner=${rc_owner##*/}
+
+    case "$rc_host" in
+      github.com)
+        RC_ICON=$RC_GH_ICON
+        RC_KIND=github
+        RC_LABEL="$rc_owner/$rc_repo"
+        ;;
+      *)
+        RC_ICON=$RC_GIT_ICON
+        RC_KIND=git
+        if [ -n "$rc_repo" ]; then
+          RC_LABEL="$rc_repo"
+        else
+          RC_LABEL=$(basename "$(git -C "$rc_dir" rev-parse --show-toplevel 2>/dev/null)")
+        fi
+        ;;
+    esac
+  else
+    # Not a git repo: folder icon + at most the last two path components.
+    RC_ICON=$RC_FOLDER_ICON
+    RC_KIND=folder
+    if [ "$rc_dir" = "$HOME" ]; then
+      RC_LABEL="~"
+    elif [ "${rc_dir%/*}" = "$HOME" ]; then
+      # literal ~ for display, not a path to expand
+      # shellcheck disable=SC2088
+      RC_LABEL="~/${rc_dir##*/}"
+    else
+      rc_leaf=${rc_dir##*/}
+      rc_parent=${rc_dir%/*}; rc_parent=${rc_parent##*/}
+      if [ -n "$rc_parent" ] && [ "$rc_parent" != "$rc_leaf" ]; then
+        RC_LABEL="$rc_parent/$rc_leaf"
+      else
+        RC_LABEL="$rc_leaf"
+      fi
+    fi
+  fi
+}

--- a/tmux/status-left.sh
+++ b/tmux/status-left.sh
@@ -6,16 +6,15 @@
 #   status-left "#(~/.tmux/status-left.sh '#{pane_current_path}')"
 #
 # Emits an already-styled left block (tmux re-parses the `#[...]` format codes
-# in this output). The left block describes the active pane's directory:
+# in this output). The active pane's directory is described by the shared
+# detector in ~/.zsh/repo-context.sh (also used by the zsh prompt):
 #
 #   GitHub repo      ->   owner/repo        + branch   (GitHub icon)
 #   other git repo   ->   repo              + branch   (git icon)
 #   not a git repo   ->   parent/dir (<=2)             (folder icon)
 #
-# A worktree icon is appended to the branch when the pane is in a linked git
+# A worktree icon replaces the branch icon when the pane is in a linked git
 # worktree (e.g. one created by workmux) rather than the main checkout.
-#
-# Git lookups are read-only (GIT_OPTIONAL_LOCKS=0, mirroring ~/.zsh/git.zsh).
 
 # --- palette (kept in sync with ~/.tmux.conf) ---------------------------------
 base="#2e3440"      # status bar background
@@ -24,94 +23,21 @@ seg1_fg="#eceff4"   # repo/path segment text
 seg2_fg="#81a1c1"   # branch text (blue), shown on the same bg as the path
 dirty_fg="#ebcb8b"  # dirty working-tree marker (yellow), mirrors the zsh prompt
 
-# --- glyphs (Nerd Font: CascadiaMonoNF), built via octal to keep this ASCII ---
-gh_icon=$(printf '\357\202\233')        # U+F09B  GitHub mark
-git_icon=$(printf '\356\234\202')       # U+E702  git
-folder_icon=$(printf '\357\201\273')    # U+F07B  folder
-branch_icon=$(printf '\357\204\246')          # U+F126  branch (normal checkout)
-worktree_branch_icon=$(printf '\356\251\243') # U+EA63  branch (linked worktree)
 slant=$(printf '\356\202\260')          # U+E0B0  solid right slant
-dirty_glyph=$(printf '\342\234\227')    # U+2717  ballot X (dirty working tree)
 
-dir="${1:-$HOME}"
-icon=""
-label=""
-branch=""
-bicon=""
+# Shared repo/path detection (icons, label, branch, dirty state).
+. "$HOME/.zsh/repo-context.sh"
+repo_context "${1:-$HOME}"
+
 dirty=""
-
-if git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  # Current branch, falling back to a short SHA when HEAD is detached.
-  branch=$(GIT_OPTIONAL_LOCKS=0 git -C "$dir" symbolic-ref --short HEAD 2>/dev/null)
-  [ -n "$branch" ] || branch=$(GIT_OPTIONAL_LOCKS=0 git -C "$dir" rev-parse --short HEAD 2>/dev/null)
-
-  # Linked worktrees live under <repo>/.git/worktrees/<name>; swap the branch
-  # icon to signal a worktree rather than appending a second glyph.
-  bicon=$branch_icon
-  case "$(git -C "$dir" rev-parse --git-dir 2>/dev/null)" in
-    */worktrees/*) bicon=$worktree_branch_icon ;;
-  esac
-
-  # Yellow cross when the working tree is dirty (untracked counts), mirroring
-  # parse_git_dirty in ~/.zsh/git.zsh.
-  if [ -n "$(GIT_OPTIONAL_LOCKS=0 git -C "$dir" status --porcelain 2>/dev/null)" ]; then
-    dirty=" #[fg=$dirty_fg]$dirty_glyph"
-  fi
-
-  # Parse host + owner/repo from the origin URL (https, ssh, or scp-like).
-  url=$(git -C "$dir" config --get remote.origin.url 2>/dev/null)
-  url=${url%.git}
-  host=""
-  path=""
-  case "$url" in
-    "") : ;;
-    *://*) rest=${url#*://}; rest=${rest#*@}; host=${rest%%/*}; path=${rest#*/} ;;
-    *@*:*) rest=${url#*@}; host=${rest%%:*}; path=${rest#*:} ;;
-    *) path=$url ;;
-  esac
-  repo=${path##*/}
-  owner=${path%/*}; owner=${owner##*/}
-
-  case "$host" in
-    github.com)
-      icon=$gh_icon
-      label="$owner/$repo"
-      ;;
-    *)
-      icon=$git_icon
-      if [ -n "$repo" ]; then
-        label="$repo"
-      else
-        label=$(basename "$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)")
-      fi
-      ;;
-  esac
-else
-  # Not a git repo: folder icon + at most the last two path components.
-  icon=$folder_icon
-  if [ "$dir" = "$HOME" ]; then
-    label="~"
-  elif [ "${dir%/*}" = "$HOME" ]; then
-    # literal ~ for display, not a path to expand
-    # shellcheck disable=SC2088
-    label="~/${dir##*/}"
-  else
-    leaf=${dir##*/}
-    parent=${dir%/*}; parent=${parent##*/}
-    if [ -n "$parent" ] && [ "$parent" != "$leaf" ]; then
-      label="$parent/$leaf"
-    else
-      label="$leaf"
-    fi
-  fi
-fi
+[ -n "$RC_DIRTY" ] && dirty=" #[fg=$dirty_fg]$RC_DIRTY_GLYPH"
 
 # Repo/path + branch on a single segment: one shared background, no separator
 # between them (just a space), then one slant into the bar background.
-printf '#[fg=%s,bg=%s,bold] %s %s' "$seg1_fg" "$seg1_bg" "$icon" "$label"
+printf '#[fg=%s,bg=%s,bold] %s %s' "$seg1_fg" "$seg1_bg" "$RC_ICON" "$RC_LABEL"
 
-if [ -n "$branch" ]; then
-  printf '#[fg=%s,bg=%s,nobold] %s %s%s' "$seg2_fg" "$seg1_bg" "$bicon" "$branch" "$dirty"
+if [ -n "$RC_BRANCH" ]; then
+  printf '#[fg=%s,bg=%s,nobold] %s %s%s' "$seg2_fg" "$seg1_bg" "$RC_BICON" "$RC_BRANCH" "$dirty"
 fi
 
 printf ' #[fg=%s,bg=%s,nobold]%s' "$seg1_bg" "$base" "$slant"


### PR DESCRIPTION
## Summary

Replaces the bare `$` prompt shown inside tmux with a two-line block plus a post-command status line:

```
┏  owner/repo
┗ $ <command>
<output>

● 1.2s
```

- **`.zsh/repo-context.sh`** (new) — extracts the repo/path detection that previously lived inline in `tmux/status-left.sh` into a shared POSIX helper. The zsh prompt and tmux status bar now describe the current directory identically: GitHub `owner/repo`, plain `repo`, or folder path, with matching Nerd Font icons. Git lookups stay read-only (`GIT_OPTIONAL_LOCKS=0`).
- **`tmux/status-left.sh`** — now sources the shared helper and only applies its `#[...]` styling. Rendered output is unchanged (pure refactor).
- **`.zsh/marcqualie.zsh-theme`** — builds the `┏`/`┗` prompt block in tmux mode and prints a status line after each command via `preexec`/`precmd` hooks: green dot on success, red dot + exit code on failure, followed by the wall-clock duration (`23ms` / `3.5s` / `1m35s`). The status line only appears after a real command runs (skipped on a fresh shell or empty line). The non-tmux prompt is unchanged.

## Test plan

- [x] `repo-context.sh` resolves GitHub/git/folder kinds correctly under both `/bin/sh` and `zsh`
- [x] `tmux/status-left.sh` output is byte-for-byte identical to before the refactor
- [x] Status line renders on success (green) and failure (red + exit code)
- [x] No status line on a fresh shell / empty line
- [x] Duration formats across ms / seconds / minutes ranges
- [x] Non-tmux prompt path unaffected