### PR TITLE
Show clickable GitHub PR number in tmux status-left

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -46,6 +46,12 @@ set -g status-style "fg=#d8dee9,bg=#2e3440"
 # Left: folder/path segment + optional git branch (rendered by the helper).
 set -g status-left "#(~/.tmux/status-left.sh '#{pane_current_path}')"
 
+# Clicking the green "#123" PR number (a range=user region in status-left) opens
+# the PR in the browser; any other status click keeps the default behaviour.
+bind -n MouseDown1Status if-shell -F "#{m:[0-9]*,#{mouse_status_range}}" \
+  "run-shell -b \"~/.tmux/open-pr.sh '#{mouse_status_range}' '#{pane_current_path}'\"" \
+  "switch-client -t ="
+
 # Window list: each tab is a slanted block; no separator so edges butt cleanly.
 set -g window-status-separator ""
 set -g window-status-format "#[fg=#2e3440,bg=#3b4252]#[fg=#7b88a1,bg=#3b4252] #{?#{==:#{pane_current_command},claude},󱜚 ,}#I #{?#{==:#{pane_title},#{host}},#W,#{=/16/…:#{pane_title}}}#{?@workmux_status, #{?#{==:#{@workmux_status},󱓦},#[fg=#ebcb8b],#{?#{==:#{@workmux_status},󰠗},#[fg=#d08770],#{?#{==:#{@workmux_status},},#[fg=#a3be8c],#[fg=#7b88a1]}}}#{@workmux_status}#[fg=#7b88a1],} #[fg=#3b4252,bg=#2e3440]"

--- a/.tmux/open-pr.sh
+++ b/.tmux/open-pr.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+#
+# open-pr.sh — open the GitHub PR clicked in the tmux status-left.
+#
+# Bound from ~/.tmux.conf as the MouseDown1Status handler. tmux cannot render
+# OSC 8 hyperlinks in the status line, so status-left.sh marks the "#123" PR
+# number as a `range=user|<number>` region instead; clicking it fires this with
+#
+#   open-pr.sh '#{mouse_status_range}' '#{pane_current_path}'
+#
+# The range value is the PR number; the pane path identifies the repo, whose
+# GitHub origin reconstructs the PR URL. Non-numeric ranges (e.g. the window
+# list) are ignored so the caller can fall back to the default click behaviour.
+
+pr=$1
+dir=$2
+
+case "$pr" in
+  ""|*[!0-9]*) exit 0 ;;   # not our numeric PR range -> let the default handle it
+esac
+
+. "$HOME/.zsh/repo-context.sh"
+repo_context "$dir"
+[ "$RC_KIND" = github ] || exit 0   # RC_LABEL is owner/repo on github.com
+
+open "https://github.com/$RC_LABEL/pull/$pr" >/dev/null 2>&1

--- a/.tmux/status-left.sh
+++ b/.tmux/status-left.sh
@@ -22,12 +22,16 @@ seg1_bg="#434c5e"   # repo/path segment background
 seg1_fg="#eceff4"   # repo/path segment text
 seg2_fg="#81a1c1"   # branch text (blue), shown on the same bg as the path
 dirty_fg="#ebcb8b"  # dirty working-tree marker (yellow), mirrors the zsh prompt
+pr_fg="#a3be8c"     # github PR link (green), distinct from the branch text
 
 slant=$(printf '\356\202\260')          # U+E0B0  solid right slant
 
 # Shared repo/path detection (icons, label, branch, dirty state).
 . "$HOME/.zsh/repo-context.sh"
 repo_context "${1:-$HOME}"
+
+# Open GitHub PR for the current branch (cached + fetched in the background).
+repo_github_pr
 
 dirty=""
 [ -n "$RC_DIRTY" ] && dirty=" #[fg=$dirty_fg]$RC_DIRTY_GLYPH"
@@ -38,6 +42,16 @@ printf '#[fg=%s,bg=%s,bold] %s %s' "$seg1_fg" "$seg1_bg" "$RC_ICON" "$RC_LABEL"
 
 if [ -n "$RC_BRANCH" ]; then
   printf '#[fg=%s,bg=%s,nobold] %s %s%s' "$seg2_fg" "$seg1_bg" "$RC_BICON" "$RC_BRANCH" "$dirty"
+fi
+
+# Matching GitHub PR rendered as "#123". tmux cannot emit OSC 8 hyperlinks in
+# the status line (the renderer drops the escape), so instead the number is a
+# clickable `range=user|<number>` region; the MouseDown1Status binding in
+# ~/.tmux.conf opens the PR via ~/.tmux/open-pr.sh. The literal '#' is doubled
+# (##) so tmux's format parser keeps it instead of reading a format directive.
+if [ -n "$RC_PR_NUMBER" ]; then
+  printf '#[fg=%s,bg=%s,nobold] #[range=user|%s]##%s#[norange]' \
+    "$pr_fg" "$seg1_bg" "$RC_PR_NUMBER" "$RC_PR_NUMBER"
 fi
 
 printf ' #[fg=%s,bg=%s,nobold]%s' "$seg1_bg" "$base" "$slant"

--- a/.zsh/repo-context.sh
+++ b/.zsh/repo-context.sh
@@ -27,14 +27,15 @@ RC_DIRTY_GLYPH=$(printf '\342\234\227')         # U+2717  ballot X (dirty workin
 #   RC_BRANCH   current branch or short SHA (empty when not a git repo)
 #   RC_BICON    branch icon (worktree variant inside a linked worktree)
 #   RC_DIRTY    1 when the working tree is dirty, else empty
+#   RC_DETACHED 1 when HEAD is detached (RC_BRANCH holds a short SHA, not a ref)
 repo_context() {
-  RC_ICON=""; RC_KIND=""; RC_LABEL=""; RC_BRANCH=""; RC_BICON=""; RC_DIRTY=""
+  RC_ICON=""; RC_KIND=""; RC_LABEL=""; RC_BRANCH=""; RC_BICON=""; RC_DIRTY=""; RC_DETACHED=""
   rc_dir="${1:-$HOME}"
 
   if git -C "$rc_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     # Current branch, falling back to a short SHA when HEAD is detached.
     RC_BRANCH=$(GIT_OPTIONAL_LOCKS=0 git -C "$rc_dir" symbolic-ref --short HEAD 2>/dev/null)
-    [ -n "$RC_BRANCH" ] || RC_BRANCH=$(GIT_OPTIONAL_LOCKS=0 git -C "$rc_dir" rev-parse --short HEAD 2>/dev/null)
+    [ -n "$RC_BRANCH" ] || { RC_DETACHED=1; RC_BRANCH=$(GIT_OPTIONAL_LOCKS=0 git -C "$rc_dir" rev-parse --short HEAD 2>/dev/null); }
 
     # Linked worktrees live under <repo>/.git/worktrees/<name>; swap the branch
     # icon to signal a worktree rather than appending a second glyph.
@@ -99,4 +100,65 @@ repo_context() {
       fi
     fi
   fi
+}
+
+# repo_github_pr
+# Resolves an open GitHub pull request for the current branch and populates:
+#   RC_PR_NUMBER   PR number (digits only), empty when none/unknown
+#   RC_PR_URL      web URL of the PR, empty when none/unknown
+#
+# Must be called after repo_context (uses RC_KIND/RC_LABEL/RC_BRANCH). The
+# `gh pr list` lookup is a network call, so results are cached on disk and the
+# refresh runs detached in the background: the status bar reads a cached answer
+# (or nothing on the very first sighting) and never blocks. Requires the GitHub
+# CLI (`gh`); silently no-ops when it is missing or unauthenticated.
+repo_github_pr() {
+  RC_PR_NUMBER=""; RC_PR_URL=""
+  [ "$RC_KIND" = github ] || return 0      # only github.com origins
+  [ -z "$RC_DETACHED" ] || return 0        # a detached SHA is not a PR head
+  [ -n "$RC_BRANCH" ] || return 0
+  command -v gh >/dev/null 2>&1 || return 0
+
+  rc_pr_cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/tmux-status"
+  # Cache key is repo + branch with path separators flattened.
+  rc_pr_key=$(printf '%s@%s' "$RC_LABEL" "$RC_BRANCH" | tr '/ :@' '____')
+  rc_pr_cache="$rc_pr_cache_dir/pr-$rc_pr_key"
+
+  # Use whatever the last lookup found (cache line is "<number> <url>" or "none").
+  if [ -f "$rc_pr_cache" ]; then
+    rc_pr_line=$(cat "$rc_pr_cache" 2>/dev/null)
+    case "$rc_pr_line" in
+      none|"") : ;;
+      *) RC_PR_NUMBER=${rc_pr_line%% *}; RC_PR_URL=${rc_pr_line#* } ;;
+    esac
+  fi
+
+  # Refresh in the background when the cache is missing or older than 5 minutes.
+  if [ -z "$(find "$rc_pr_cache" -mmin -5 2>/dev/null)" ]; then
+    ( rc_github_pr_fetch "$RC_LABEL" "$RC_BRANCH" "$rc_pr_cache" >/dev/null 2>&1 & )
+  fi
+}
+
+# rc_github_pr_fetch <owner/repo> <branch> <cache-file>
+# Background worker: queries the GitHub CLI for the open PR whose head is
+# <branch> and writes "<number> <url>" (or "none") to <cache-file> atomically.
+# Single-flighted via a lock dir so overlapping status ticks fire one fetch.
+rc_github_pr_fetch() {
+  _repo=$1; _branch=$2; _cache=$3
+  mkdir -p "$(dirname "$_cache")" 2>/dev/null
+
+  _lock="$_cache.lock"
+  if [ -d "$_lock" ]; then
+    # Fresh lock => another fetch is in flight; stale lock => reclaim it.
+    [ -n "$(find "$_lock" -mmin -1 2>/dev/null)" ] && return 0
+    rmdir "$_lock" 2>/dev/null
+  fi
+  mkdir "$_lock" 2>/dev/null || return 0
+
+  _pr=$(gh pr list --repo "$_repo" --head "$_branch" --state open \
+          --json number,url --jq '.[0] | select(.number) | "\(.number) \(.url)"' 2>/dev/null)
+  [ -n "$_pr" ] || _pr=none
+  printf '%s\n' "$_pr" > "$_cache.tmp" 2>/dev/null && mv "$_cache.tmp" "$_cache" 2>/dev/null
+
+  rmdir "$_lock" 2>/dev/null
 }

--- a/.zsh/repo-context.sh
+++ b/.zsh/repo-context.sh
@@ -28,9 +28,11 @@ RC_DIRTY_GLYPH=$(printf '\342\234\227')         # U+2717  ballot X (dirty workin
 #   RC_BICON    branch icon (worktree variant inside a linked worktree)
 #   RC_DIRTY    1 when the working tree is dirty, else empty
 #   RC_DETACHED 1 when HEAD is detached (RC_BRANCH holds a short SHA, not a ref)
+#   RC_DIR      the directory that was inspected (used by repo_github_pr)
 repo_context() {
   RC_ICON=""; RC_KIND=""; RC_LABEL=""; RC_BRANCH=""; RC_BICON=""; RC_DIRTY=""; RC_DETACHED=""
   rc_dir="${1:-$HOME}"
+  RC_DIR="$rc_dir"
 
   if git -C "$rc_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     # Current branch, falling back to a short SHA when HEAD is detached.
@@ -118,6 +120,11 @@ repo_github_pr() {
   [ -z "$RC_DETACHED" ] || return 0        # a detached SHA is not a PR head
   [ -n "$RC_BRANCH" ] || return 0
   command -v gh >/dev/null 2>&1 || return 0
+
+  # Only a branch that has been pushed can have a PR. The remote-tracking ref
+  # refs/remotes/origin/<branch> appears once it is pushed, so this stays a
+  # purely local check (no network) that skips brand-new local-only branches.
+  git -C "$RC_DIR" show-ref --verify --quiet "refs/remotes/origin/$RC_BRANCH" 2>/dev/null || return 0
 
   rc_pr_cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/tmux-status"
   # Cache key is repo + branch with path separators flattened.


### PR DESCRIPTION
## Summary

Extends the custom tmux `status-left` git detection so that, when the active pane is in a **github.com** repo on a real branch, the matching **open PR** is detected and rendered as a green `#123` after the branch name. Clicking it opens the PR in the browser.

## How it works

- **`.zsh/repo-context.sh`** (shared by the zsh prompt and tmux status):
  - `repo_context` now flags detached HEAD (`RC_DETACHED`) so a bare SHA isn't treated as a PR head.
  - New `repo_github_pr` resolves the PR via `gh pr list --head <branch> --state open`. Because the status bar refreshes every 5s, the lookup is **cached on disk** (5-minute TTL) and refreshed by a **single-flighted background worker** (`rc_github_pr_fetch`), so rendering never blocks on the network.

- **`.tmux/status-left.sh`**: renders the PR as a `#[range=user|<number>]` clickable region. tmux's status-line renderer strips raw OSC 8 escapes, so terminal hyperlinks aren't possible there — a tmux `range` is used instead.

- **`.tmux/open-pr.sh`** + **`MouseDown1Status` binding** (`.tmux.conf`): clicking the green PR number reconstructs the URL from the pane's GitHub origin and opens it. Non-numeric ranges (e.g. the window list) fall back to the default `switch-client -t =`.

## Notes / trade-offs

- Click-to-open is via tmux (mouse is already enabled), not a true terminal hyperlink — no cmd-click/hover underline.
- `open` is macOS-specific, matching this darwin config.

## Testing

- Verified `gh` resolves PR #3254 for branch `ci-verify-circleci-config` and writes `none` for branches without a PR.
- Confirmed the rendered output contains no stray escape bytes and the `MouseDown1Status` binding registers correctly.